### PR TITLE
performance: avoid paying decodeFastbootSwitch regex cost unless needed

### DIFF
--- a/packages/core/src/virtual-content.ts
+++ b/packages/core/src/virtual-content.ts
@@ -150,6 +150,10 @@ export function fastbootSwitch(specifier: string, fromFile: string, names: Set<s
 }
 
 export function decodeFastbootSwitch(filename: string) {
+  // Performance: avoid paying regex exec cost unless needed
+  if (!filename.includes(fastbootSwitchSuffix)) {
+    return;
+  }
   let match = fastbootSwitchPattern.exec(filename);
   if (match) {
     let names = match.groups?.names?.split(',') ?? [];


### PR DESCRIPTION
Before this change, my large app was spending 20+ seconds on the regex:

<img width="849" alt="Screenshot 2023-09-25 at 9 58 19 AM" src="https://github.com/raycohen/embroider/assets/20404/29af0e7e-810c-4d26-885e-3b1397796030">

After this change, it spends no time here (my app does not use fastboot, so the condition is never met). I think this condition will be correct for users that do use fastboot.