### PR TITLE
only require.resolve the babel plugin cache busting file once

### DIFF
--- a/packages/macros/src/macros-config.ts
+++ b/packages/macros/src/macros-config.ts
@@ -70,6 +70,10 @@ function gatherAddonCacheKey(project: any): string {
   return cacheKey;
 }
 
+const babelCacheBustingPluginPath: string = require.resolve(
+  '@embroider/shared-internals/src/babel-plugin-cache-busting.js'
+);
+
 export default class MacrosConfig {
   static for(key: any, appRoot: string): MacrosConfig {
     let found = localSharedState.get(key);
@@ -370,11 +374,7 @@ export default class MacrosConfig {
 
     return [
       [join(__dirname, 'babel', 'macros-babel-plugin.js'), opts],
-      [
-        require.resolve('@embroider/shared-internals/src/babel-plugin-cache-busting.js'),
-        { version: cacheKey },
-        `@embroider/macros cache buster: ${owningPackageRoot}`,
-      ],
+      [babelCacheBustingPluginPath, { version: cacheKey }, `@embroider/macros cache buster: ${owningPackageRoot}`],
     ];
   }
 


### PR DESCRIPTION
The result shouldn't change. This currently gets hit many times during the ember-cli addon initialization phase as part of `babelPluginConfig`, and also once for each rebuild.